### PR TITLE
Add feature: Platform Detection

### DIFF
--- a/pre-installations.sh
+++ b/pre-installations.sh
@@ -1,13 +1,39 @@
 #!/bin/bash
 
-# Update and upgrade the system
-sudo apt update && sudo apt upgrade -y
+# Detect the operating system
+if [[ -f /etc/debian_version ]]; then
+    #Debian
 
-# Install Python
-sudo apt install -y python3 python3-pip
+    echo "Debian based System Detected"
+    echo "Updating and upgrading system"
 
-# Install additional packages
-sudo apt-get install -y git
-sudo apt install -y python3-pip
+    sudo apt update && sudo apt upgrade -y
+    sudo apt install -y python3 python3-pip git
 
-echo "All tasks completed successfully!"
+    echo "All tasks completed successfully!"
+
+elif [[ -f /etc/arch-release ]]; then
+    #Arch Linux
+
+    echo "Arch-Linux Detected"
+    echo "Updating and upgrading system."
+
+    sudo pacman -Syu --noconfirm
+    sudo pacman -S --noconfirm python python-pip git
+
+    echo "All tasks completed successfully!"
+
+elif [[ -f /etc/fedora-release ]]; then
+    #RHEL
+
+    echo "Red Hat Linux Detected"
+    echo "Updating and upgrading system"
+
+    sudo dnf update -y
+    sudo dnf install -y python3 python3-pip git
+
+    echo "All tasks completed successfully"
+
+else
+    echo "Unsupported Linux distribution"
+fi


### PR DESCRIPTION
## Commit Summary: Implement Platform Detection in pre-installations.sh

This commit implements the **Platform Detection** feature in the `pre-installations.sh` script. It includes checks for various Linux distributions (Debian/Ubuntu, Arch Linux, Fedora) to ensure proper installation of required packages.

### Key Changes:
- The script now dynamically identifies the operating system and executes the appropriate installation commands based on the detected platform.
- Added specific checks for:
  - **Debian/Ubuntu**
  - **Arch Linux**
  - **Fedora**

### Note:
No support for Windows-based systems is provided because Windows doesn't have a dedicated package manager and this program overall doesn't work with windows
